### PR TITLE
Add CJS compilation back to support backwards compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
+  "main": "./dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -30,8 +32,8 @@
   ],
   "scripts": {
     "audit:fix": "pnpm audit --fix",
-    "build": "tsup src/index.ts --format esm --dts --sourcemap external --clean",
-    "watch": "tsup src/index.ts --format esm --dts --sourcemap external --watch",
+    "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap external --clean",
+    "watch": "tsup src/index.ts --format cjs,esm --dts --sourcemap external --watch",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
**Changes:**  Supporting only ES Modules is breaking libraries that still has CJS support so this change is to add back support for CJS for now until everyone has upgraded.